### PR TITLE
Allow non https connections

### DIFF
--- a/hoover/handlers.py
+++ b/hoover/handlers.py
@@ -12,7 +12,7 @@ from hoover.utils import async_post_to_endpoint
 
 class LogglyHttpHandler(logging.Handler):
     def __init__(self, session=None, token='', inputname='', input=None,
-                 announce=False, json_class=None):
+                 announce=False, json_class=None, https = True):
         logging.Handler.__init__(self)
         if inputname:
             # TODO: raise something appropriate if session is None
@@ -26,7 +26,10 @@ class LogglyHttpHandler(logging.Handler):
                 raise ValueError('This is not an HTTP input')
         session = session or LogglySession
         self.token = token
-        self.endpoint = "https://%s/inputs/%s" % (session.proxy, token)
+        if https:
+            self.endpoint = "https://%s/inputs/%s" % (session.proxy, token)
+        else:
+            self.endpoint = "http://%s/inputs/%s" % (session.proxy, token)
         self.json_class = json_class
         # TODO: verify we can write to the input
         if announce:


### PR DESCRIPTION
I have trouble to use HTTPS on dotcloud.com.

Please note the patch have been made from github webinterface and probably request a syntax check.
