### PR TITLE
Handle unicode logging

### DIFF
--- a/hoover/utils.py
+++ b/hoover/utils.py
@@ -22,8 +22,14 @@ def async(func):
     return wraps(func)(newfunc)
 
 
-def post_to_endpoint(endpoint, message):
+def post_to_endpoint(endpoint, message, encoding='utf-8'):
     h = Http()
+    # If unicode, try to encode
+    if isinstance(message, unicode):
+        try:
+            message = message.encode(encoding)
+        except UnicodeEncodeError:
+            pass
     h.request(endpoint, 'POST', message)
 async_post_to_endpoint = async(post_to_endpoint)
 


### PR DESCRIPTION
Currently, unicode characters blow up. This safely encodes incoming unicode so that we can send it via http.
