### PR TITLE
Fix side effect of record modified affecting the next in line handler.

### DIFF
--- a/hoover/handlers.py
+++ b/hoover/handlers.py
@@ -1,6 +1,9 @@
 '''A couple of logging handlers which should play nicely with the Python
 logging library.'''
 import sys, logging, socket
+
+import copy
+
 try:
     from simplejson import dumps
 except ImportError:
@@ -37,6 +40,8 @@ class LogglyHttpHandler(logging.Handler):
 
     def emit(self, record):
         if isinstance(record.msg, (list, dict)):
+            # prevent sideffect for other handlers processing the same record.
+            record = copy.copy(record)
             record.msg = dumps(record.msg, cls=self.json_class, default=str)
         msg = self.format(record)
         async_post_to_endpoint(self.endpoint, msg)


### PR DESCRIPTION
The existing code handling a Log Record having a dict data as message , process it as json by modifying the the record and delegating it.

Some other log handler expecting the message as dict would fail since hoover has changed the log record.

The fix is using python shallow clone copy.copy which is modified and used by hoover without changing the code for the original LogRecord.